### PR TITLE
fixed invalid datetime_input_formats addition

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -806,8 +806,11 @@ BING_API_KEY = os.environ.get('BING_API_KEY', None)
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', None)
 
 # handle timestamps like 2017-05-30 16:04:00.719 UTC
-DATETIME_INPUT_FORMATS = DATETIME_INPUT_FORMATS +\
-    ['%Y-%m-%d %H:%M:%S.%f %Z', '%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S%Z']
+DATETIME_INPUT_FORMATS += (
+    '%Y-%m-%d %H:%M:%S.%f %Z',
+    '%Y-%m-%dT%H:%M:%S.%f',
+    '%Y-%m-%dT%H:%M:%S%Z',
+)
 
 MAP_BASELAYERS = [{
     "source": {"ptype": "gxp_olsource"},


### PR DESCRIPTION
This PR fixes a typo in `settings.py` where the `DATETIME_INPUT_FORMATS` variable was being updated by concatenating with a list. This variable was a tuple, and the concatenation threw python's `TypeError`:

```python
Traceback (most recent call last):
  File "manage.py", line 31, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 354, in execut
e_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 303, in execut
e
    settings.INSTALLED_APPS
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 44, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 92, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/ricardo/dev/gfdrr-det/src/geonode/geonode/settings.py", line 810, in <module>
    ['%Y-%m-%d %H:%M:%S.%f %Z', '%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S%Z']
TypeError: can only concatenate tuple (not "list") to tuple

```