### PR TITLE
Move sync permission button

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -684,6 +684,9 @@
       <h4>{% trans "Permissions" %}</h4>
       <p>{% trans "Click the button below to change the permissions of this layer." %}</p>
       <p><a href="#modal_perms" data-toggle="modal" class="btn btn-primary btn-block" data-target="#_permissions">{% trans "Change Layer Permissions" %}</a></p>
+      {% if USE_GEOSERVER %}
+        <a href="#" class="btn btn-primary btn-block" data-dismiss="modal" id="security_refresh">{% trans "Sync permissions immediately" %}</a>
+      {% endif %}
     </li>
     {% endif %}
     {% endif %}

--- a/geonode/templates/_permissions_form.html
+++ b/geonode/templates/_permissions_form.html
@@ -13,9 +13,6 @@
         </div>
         <div class="modal-footer">
           <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
-          {% if USE_GEOSERVER %}
-            <a href="#" class="btn btn-primary" data-dismiss="modal" id="security_refresh">{% trans "Sync Security Cache" %}</a>
-          {% endif %}
           <a href="#" class="btn btn-primary" data-dismiss="modal" id="perms_submit">{% trans "Apply Changes" %}</a>
         </div>
       </div>


### PR DESCRIPTION
With this PR the "Sync Security Cache" button has been moved from the "Set permissions for this resource" modal window to the "Permissions" section of the layer detail view.
It has been renamed as "Sync permissions immediately".

Fix [this issue](https://github.com/geosolutions-it/C152-HARVARD/issues/8).