### PR TITLE
Geonode logo as favicon

### DIFF
--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -34,6 +34,9 @@
     <meta Http-Equiv="Cache-directive: no-cache">
 
     <title>{% block title %}{{ SITE_NAME }}{% endblock %}</title>
+
+    <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+
     {% block head %}
       {% if DEBUG_STATIC %}
           <link href="{% static "lib/css/jquery.dataTables.css" %}?v={{ VERSION }}" rel="stylesheet" />


### PR DESCRIPTION
With this PR the GeoNode logo has been set as favicon in the `base.html` template.
Ref the [issue 128](https://github.com/geosolutions-it/geonode-mapstore-client/issues/128) of the [geonode-mapstore-client](https://github.com/geosolutions-it/geonode-mapstore-client) project.