### PR TITLE
set_layers_permisions management command

### DIFF
--- a/docs/tutorials/admin/admin_mgmt_commands/index.txt
+++ b/docs/tutorials/admin/admin_mgmt_commands/index.txt
@@ -308,3 +308,55 @@ Usage::
 
   # remove layers which are broken
   python manage.py find_geoserver_broken_layers --remove
+
+
+set_layers_permissions
+======================
+
+Set/Unset permissions on layers for users and groups.
+
+Usage::
+
+    python manage.py set_layers_permissions [-h] [--version] [-v {0,1,2,3}]
+                                            [--settings SETTINGS]
+                                            [--pythonpath PYTHONPATH]
+                                            [--traceback] [--no-color]
+                                            [-r [RESOURCES [RESOURCES ...]]]
+                                            [-p PERMISSION]
+                                            [-u [USERS [USERS ...]]]
+                                            [-g [GROUPS [GROUPS ...]]]
+                                            [-d]
+
+    At least one user or one group is required.
+    If no resources are typed all the layers will be considered.
+    At least one permission must be typed.
+    Multiple inputs can be typed with white space separator.
+    To unset permissions use the '--delete (-d)' option.
+
+
+Arguments::
+
+    -h, --help            show this help message and exit
+    --version             show program's version number and exit
+    -v {0,1,2,3}, --verbosity {0,1,2,3}
+                        Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output
+    --settings SETTINGS     The Python path to a settings module, e.g. "myproject.settings.main".
+                            If this isn't provided, the DJANGO_SETTINGS_MODULE environment variable will be used.
+    --pythonpath PYTHONPATH
+                        A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".
+    --traceback           Raise on CommandError exceptions
+    --no-color            Don't colorize the command output.
+    -r [RESOURCES [RESOURCES ...]], --resources [RESOURCES [RESOURCES ...]]
+                        Resources names for which permissions will be assigned to.
+                        Default value: None (all the layers will be considered).
+                        Multiple choices can be typed with white space separator.
+                        A Note: names with white spaces must be typed inside quotation marks.
+    -p PERMISSION, --permission PERMISSION
+                        Permissions to be assigned. Allowed values are: read (r), write (w), download (d) and owner (o).
+    -u [USERS [USERS ...]], --users [USERS [USERS ...]]
+                        Users for which permissions will be assigned to.
+                        Multiple choices can be typed with white space separator.
+    -g [GROUPS [GROUPS ...]], --groups [GROUPS [GROUPS ...]]
+                        Groups for which permissions will be assigned to.
+                        Multiple choices can be typed with white space separator.
+    -d, --delete          Delete permission if it exists.

--- a/geonode/layers/management/commands/set_layers_permissions.py
+++ b/geonode/layers/management/commands/set_layers_permissions.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2019 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.core.management.base import BaseCommand
+from argparse import RawTextHelpFormatter
+from geonode.layers.models import Layer
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
+
+
+class Command(BaseCommand):
+
+    help = """
+    Set/Unset permissions on layers for users and groups.
+    Arguments:
+        - users (-u, --users)
+        - groups (-g, --groups)
+        - resources (-r, --resources)
+        - permissions (-p, --permissions)
+        - delete (-d, --delete)
+    At least one user or one group is required.
+    If no resources are typed all the layers will be considered.
+    At least one permission must be typed.
+    Multiple inputs can be typed with white space separator.
+    To unset permissions use the '--delete (-d)' option.
+    """
+
+    READ_PERMISSIONS = [
+        'view_resourcebase'
+    ]
+
+    WRITE_PERMISSIONS = [
+        'change_layer_data',
+        'change_layer_style',
+        'change_resourcebase_metadata'
+    ]
+
+    DOWNLOAD_PERMISSIONS = [
+        'download_resourcebase'
+    ]
+
+    OWNER_PERMISSIONS = [
+        'change_resourcebase',
+        'delete_resourcebase',
+        'change_resourcebase_permissions',
+        'publish_resourcebase'
+    ]
+
+    def create_parser(self, *args, **kwargs):
+        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-r',
+            '--resources',
+            dest='resources',
+            nargs='*',
+            type=str,
+            default=None,
+            help='Resources names for which permissions will be assigned to. '
+                 'Default value: None (all the layers will be considered). '
+                 'Multiple choices can be typed with white space separator.'
+                 'A Note: names with white spaces must be typed inside quotation marks.'
+        )
+        parser.add_argument(
+            '-p',
+            '--permission',
+            dest='permission',
+            type=str,
+            default=None,
+            help='Permissions to be assigned. '
+                 'Allowed values are: read (r), write (w), download (d) and owner (o).'
+        )
+        parser.add_argument(
+            '-u',
+            '--users',
+            dest='users',
+            nargs='*',
+            type=str,
+            default=None,
+            help='Users for which permissions will be assigned to. '
+                 'Multiple choices can be typed with white space separator.'
+        )
+        parser.add_argument(
+            '-g',
+            '--groups',
+            dest='groups',
+            nargs='*',
+            type=str,
+            default=None,
+            help='Groups for which permissions will be assigned to. '
+                 'Multiple choices can be typed with white space separator.'
+        )
+        parser.add_argument(
+            '-d',
+            '--delete',
+            dest='delete_flag',
+            action='store_true',
+            default=False,
+            help='Delete permission if it exists.'
+        )
+
+    def handle(self, *args, **options):
+        # Retrieving the arguments
+        resources_names = options.get('resources')
+        permissions_name = options.get('permission')
+        users_usernames = options.get('users')
+        groups_names = options.get('groups')
+        delete_flag = options.get('delete_flag')
+        # Processing information
+        if not resources_names:
+            # If resources is None we consider all the existing layer
+            resources = Layer.objects.all()
+        else:
+            try:
+                resources = Layer.objects.filter(title__in=resources_names)
+            except Layer.DoesNotExist:
+                self.stdout.write(
+                    'Warning - No resources have been found with these names: {}.'.format(
+                        ", ".join(resources_names)
+                    )
+                )
+        if not resources:
+            self.stdout.write("Err - No resources have been found. No update operations have been executed.")
+        else:
+            # PERMISSIONS
+            if not permissions_name:
+                self.stdout.write("Err - No permissions have been provided.")
+            else:
+                permissions = []
+                if permissions_name.lower() in ('read', 'r'):
+                    if not delete_flag:
+                        permissions = self.READ_PERMISSIONS
+                    else:
+                        permissions = self.READ_PERMISSIONS + self.WRITE_PERMISSIONS \
+                                      + self.DOWNLOAD_PERMISSIONS + self.OWNER_PERMISSIONS
+                elif permissions_name.lower() in ('write', 'w'):
+                    if not delete_flag:
+                        permissions = self.READ_PERMISSIONS + self.WRITE_PERMISSIONS
+                    else:
+                        permissions = self.WRITE_PERMISSIONS
+                elif permissions_name.lower() in ('download', 'd'):
+                    if not delete_flag:
+                        permissions = self.READ_PERMISSIONS + self.DOWNLOAD_PERMISSIONS
+                    else:
+                        permissions = self.DOWNLOAD_PERMISSIONS
+                elif permissions_name.lower() in ('owner', 'o'):
+                    if not delete_flag:
+                        permissions = self.READ_PERMISSIONS + self.WRITE_PERMISSIONS \
+                                      + self.DOWNLOAD_PERMISSIONS + self.OWNER_PERMISSIONS
+                    else:
+                        permissions = self.OWNER_PERMISSIONS
+                if not permissions:
+                    self.stdout.write(
+                        "Err - Permission must match one of these values: read (r), write (w), download (d), owner (o)."
+                    )
+                else:
+                    if not users_usernames and not groups_names:
+                        self.stdout.write(
+                            "Err - At least one user or one group must be provided."
+                        )
+                    else:
+                        # USERS
+                        users = []
+                        if users_usernames:
+                            User = get_user_model()
+                            for username in users_usernames:
+                                try:
+                                    user = User.objects.get(username=username)
+                                    users.append(user)
+                                except User.DoesNotExist:
+                                    self.stdout.write(
+                                        'Warning! - The user {} does not exists. '
+                                        'It has been skipped.'.format(username)
+                                    )
+                        # GROUPS
+                        groups = []
+                        if groups_names:
+                            for group_name in groups_names:
+                                try:
+                                    group = Group.objects.get(name=group_name)
+                                    groups.append(group)
+                                except Group.DoesNotExist:
+                                    self.stdout.write(
+                                        'Warning! - The group {} does not exists. '
+                                        'It has been skipped.'.format(group_name)
+                                    )
+                        if not users and not groups:
+                            self.stdout.write(
+                                'Err - Neither users nor groups corresponding to the typed names have been found. '
+                                'No update operations have been executed.'
+                            )
+                        else:
+                            # RESOURCES
+                            for resource in resources:
+                                # Existing permissions on the resource
+                                perm_spec = resource.get_all_level_info()
+                                self.stdout.write(
+                                    "Initial permissions info for the resource {}:\n{}".format(
+                                        resource.title, str(perm_spec))
+                                )
+                                for u in users:
+                                    # Add permissions
+                                    if not delete_flag:
+                                        # Check the permission already exists
+                                        if u not in perm_spec["users"]:
+                                            perm_spec["users"][u] = permissions
+                                        else:
+                                            u_perms_list = perm_spec["users"][u]
+                                            base_set = set(u_perms_list)
+                                            target_set = set(permissions)
+                                            perm_spec["users"][u] = list(base_set | target_set)
+                                    # Delete permissions
+                                    else:
+                                        # Skip resource owner
+                                        if u != resource.owner:
+                                            if u in perm_spec["users"]:
+                                                u_perms_set = set()
+                                                for up in perm_spec["users"][u]:
+                                                    if up not in permissions:
+                                                        u_perms_set.add(up)
+                                                perm_spec["users"][u] = list(u_perms_set)
+                                            else:
+                                                self.stdout.write(
+                                                    "Warning! - The user {} does not have "
+                                                    "any permission on the layer {}. "
+                                                    "It has been skipped.".format(u, resource.title)
+                                                )
+                                        else:
+                                            self.stdout.write(
+                                                "Warning! - The user {} is the layer {} owner, "
+                                                "so its permissions can't be changed. "
+                                                "It has been skipped.".format(u, resource.title)
+                                            )
+                                for g in groups:
+                                    # Add permissions
+                                    if not delete_flag:
+                                        # Check the permission already exists
+                                        if g not in perm_spec["groups"]:
+                                            perm_spec["groups"][g] = permissions
+                                        else:
+                                            g_perms_list = perm_spec["groups"][g]
+                                            base_set = set(g_perms_list)
+                                            target_set = set(permissions)
+                                            perm_spec["groups"][g] = list(base_set | target_set)
+                                    # Delete permissions
+                                    else:
+                                        if g in perm_spec["groups"]:
+                                            g_perms_set = set()
+                                            for gp in perm_spec["groups"][g]:
+                                                if gp not in permissions:
+                                                    g_perms_set.add(gp)
+                                            perm_spec["groups"][g] = list(g_perms_set)
+                                        else:
+                                            self.stdout.write(
+                                                "Warning! - The group {} does not have any permission on the layer {}. "
+                                                "It has been skipped.".format(g, resource.title)
+                                            )
+                                # Set final permissions
+                                resource.set_permissions(perm_spec)
+                                self.stdout.write(
+                                    "Final permissions info for the resource {}:\n"
+                                    "{}".format(resource.title, str(perm_spec))
+                                )
+                            self.stdout.write("Permissions successfully updated!")


### PR DESCRIPTION
This PR introduces a new management command to set/unset permissions on layers for users and groups.
The command arguments:
- **permissions** to set/unset --> read (r), write (w), download (d), owner (o)
    ```
    READ_PERMISSIONS = [
        'view_resourcebase'
    ]
    WRITE_PERMISSIONS = [
        'change_layer_data',
        'change_layer_style',
        'change_resourcebase_metadata'
    ]
    DOWNLOAD_PERMISSIONS = [
        'download_resourcebase'
    ]
    OWNER_PERMISSIONS = [
        'change_resourcebase',
        'delete_resourcebase',
        'change_resourcebase_permissions',
        'publish_resourcebase'
    ]
    ```
- **resources** (layers) which permissions will be assigned on --> type the layer title (use quotation mark for titles with white space), multiple choices can be typed with white space separator, if no titles are privided all the layers will be considered
- **users** who permissions will be assigned to, multiple choices can be typed with white space separator
- **groups** who permissions will be assigned to, multiple choices can be typed with white space separator
- **delete** flag (optional) which means the permissions will be unset

Usage examples:

`python manage.py set_layers-permissions -p write -u user_A user_B -g group_C -r layer_X 'layer Y'`
Assign **write** permissions on the layers **layer_X** and **layer Y** to the users **user_A** and **user_B** and to the group **group_C**.

`python manage.py set_layers-permissions -p owner -g group_C`
Assign **owner** permissions on all the layers to the group **group_C**.

`python manage.py set_layers-permissions -p download -u user_A -r layer_X -d`
Unset **download** permissions on the layer **layer_X** for the user **user_A**.

Documentation update at Docs » Tutorials » Administrators Workshop » Management Commands for GeoNode.