### PR TITLE
Ldap auth backend

### DIFF
--- a/docs/tutorials/admin/ldap/index.txt
+++ b/docs/tutorials/admin/ldap/index.txt
@@ -4,8 +4,25 @@
 LDAP configuration
 ==================
 
-Library Dependencies
-====================
+For integration with LDAP servers it is possible to use
+the `django_auth_ldap`_ package. This package provides a lot of flexibility in
+mapping LDAP users to geonode users and is able to manage user authentication.
+However, in order to provide support for geonode groups and enforce group
+permissions on resources, we recommend using ``django_auth_ldap`` together
+with the utilities provided in the ``geonode.contrib.ldap`` app.
+
+If you want to extract group information from LDAP and map it to geonode
+permissions you will need to use the auth backend supplied in
+``geonode.contrib.ldap``. This authentication backend is used together with
+``django_auth_ldap`` and provides compatibility with the geonode groups.
+
+Even though ``django_auth_ldap`` already provides a very flexible way to manage
+group mappings, since geonode currently implements a non-standard way of
+managing its groups and users, a custom auth backend is needed
+
+
+Installation
+------------
 
 LDAP support requires LDAP development libraries
 
@@ -19,39 +36,111 @@ LDAP support requires LDAP development libraries
 
    .. code-block:: console
 
-        $sudo apt-get install -y libldap2-dev
+        $sudo apt install libldap2-dev libsasl2-dev
 
-Install
-=======
+
+Then install the python libraries
 
    .. code-block:: console
 
         $pip install python-ldap django-auth-ldap
 
-Configure
-=========
+Note that ``geonode.contrib.ldap`` is already installed when you install geonode
 
-Add the following to your local_settings.py
 
-**Note: Example only** - more details can be found `here <https://pythonhosted.org/django-auth-ldap/authentication.html>`_
+Configuration
+-------------
 
-.. code-block:: console
+#. Add ``geonode.contrib.ldap.backend.GeonodeLdapBackend`` as an additional auth
+   backend (see example configuration below).
 
-        import ldap
-        from django_auth_ldap.config import LDAPSearch
+   You may use additional auth backends, the django authentication framework
+   tries them all according to the order listed in the settings. This means that
+   geonode can be setup in such a way as to permit internal organization users
+   to login with their LDAP credentials, while at the same time allowing for
+   casual users to use their facebook login (as long as you enable facebook
+   social auth provider).
 
-        AUTHENTICATION_BACKENDS = (
-            'django_auth_ldap.backend.LDAPBackend',
-            'django.contrib.auth.backends.ModelBackend',
-            'guardian.backends.ObjectPermissionBackend',
-        )
-        AUTH_LDAP_SERVER_URI = 'ldap://ldap.example.com'
-        LDAP_SEARCH_DN = 'ou=users,dc=example,dc=com'
-        AUTH_LDAP_USER = '(uid=%(user)s)'
-        AUTH_LDAP_BIND_DN = '{ADD_BIND_DN_IF_REQUIRED}'
-        AUTH_LDAP_BIND_PASSWORD = '{ADD_BIND_PASSWORD_IF_REQUIRED}'
-        AUTH_LDAP_USER_ATTR_MAP = {
-            'first_name': 'givenName', 'last_name': 'sn', 'email': 'mail',
-        }
-        AUTH_LDAP_USER_SEARCH = LDAPSearch(LDAP_SEARCH_DN,
-                                           ldap.SCOPE_SUBTREE, AUTH_LDAP_USER)
+   Note that django's ``django.contrib.auth.backends.ModelBackend`` must also
+   be used in order to provide full geonode integration with LDAP.
+
+#. Set some additional configuration values. Some of these variables are
+   prefixed with ``AUTH_LDAP`` (these are used directly by ``django_auth_ldap``)
+   while others are prefixed with ``GEONODE_LDAP`` (these are used by
+   ``geonode.contrib.ldap``). The geonode custom variables are:
+
+   * ``GEONODE_LDAP_GROUP_PROFILE_FILTERSTR`` - This is an LDAP search fragment
+     with the filter that allows querying for existing groups. See example below
+
+   * ``GEONODE_LDAP_GROUP_NAME_ATTRIBUTE`` - This is the name of the LDAP
+     attribute that will be used for deriving the geonode group name. If not
+     specified it will default to ``cn``, which means that the LDAP object's
+     ``common name`` will be used for generating the name of the geonode group
+
+   Example configuration::
+
+    # add these import lines to the top of your geonode settings file
+    from django_auth_ldap import config as ldap_config
+    from geonode.contrib.ldap.config import GeonodeNestedGroupOfNamesType
+    import ldap
+
+    # add both standard ModelBackend auth and geonode.contrib.ldap auth
+    AUTHENTICATION_BACKENDS = (
+        'django.contrib.auth.backends.ModelBackend',
+        'geonode.contrib.ldap.backend.GeonodeLdapBackend',
+    )
+
+    # django_auth_ldap configuration
+    AUTH_LDAP_SERVER_URI = 'ldap://example.com'
+    AUTH_LDAP_BIND_DN = 'cn=admin,dc=example,dc=com'
+    AUTH_LDAP_BIND_PASSWORD = 'something-secret'
+    AUTH_LDAP_USER_SEARCH = ldap_config.LDAPSearch(
+        'ou=people,dc=example,dc=com',
+        ldap.SCOPE_SUBTREE,
+        '(cn=%(user)s)'
+    )
+    AUTH_LDAP_GROUP_SEARCH = ldap_config.LDAPSearch(
+        'ou=groups,dc=example,dc=com',
+        ldap.SCOPE_SUBTREE,
+    )
+    AUTH_LDAP_GROUP_TYPE = GeonodeNestedGroupOfNamesType()
+    AUTH_LDAP_USER_ATTR_MAP = {
+        'first_name': 'cn',
+        'last_name": 'sn'
+    }
+    AUTH_LDAP_FIND_GROUP_PERMS = True
+    AUTH_LDAP_MIRROR_GROUPS_EXCEPT = [
+        'test_group'
+    ]
+
+    # geonode.contrib.ldap configuration
+    GEONODE_LDAP_GROUP_NAME_ATTRIBUTE = "cn"
+    GEONODE_LDAP_GROUP_PROFILE_FILTERSTR = "(ou=research group)"
+
+
+   The configuration seen in the example above will allow LDAP users to login to
+   geonode with their LDAP credentials.
+
+   On first login, a geonode user is created from the LDAP user and its LDAP
+   attributes ``cn`` and ``sn`` are used to populate the geonode user's
+   ``first_name`` and ``last_name`` profile fields.
+
+   Any groups that the user is a member of in LDAP (under the
+   ``ou=groups,dc=example,dc=com`` search base and with an
+   ``(ou=research group)`` attribute) will be mapped to the corresponding
+   geonode groups, even creating these groups in geonode in case they do not
+   exist. The geonode user is also made a member of these geonode groups.
+
+   Upon each login, the user's geonode group memberships are re-evaluated
+   according to the information extracted from LDAP. The
+   ``AUTH_LDAP_MIRROR_GROUPS_EXCEPT`` setting can be used to specify groups
+   whose memberships will not be re-evaluated.
+
+   You may also manually generate the geonode groups in advance, before users
+   login. In this case, when a user logs in and the mapped LDAP group already
+   exists, the user is merely added to the geonode group
+
+   Be sure to check out `django_auth_ldap`_ for more information on the various
+   configuration options.
+
+.. _django_auth_ldap: https://django-auth-ldap.readthedocs.io/en/latest/

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -25,7 +25,7 @@ import logging
 import traceback
 
 from pyproj import transform, Proj
-from urlparse import urljoin, urlsplit
+from urlparse import urlsplit
 
 from django.db import models
 from django.core import serializers
@@ -1133,7 +1133,6 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     # Note - you should probably broadcast layer#post_save() events to ensure
     # that indexing (or other listeners) are notified
     def save_thumbnail(self, filename, image):
-        upload_to = 'thumbs/'
         upload_path = os.path.join('thumbs/', filename)
 
         try:
@@ -1143,16 +1142,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                 # will create a new file with a unique name
                 storage.delete(os.path.join(upload_path))
 
-            storage.save(upload_path, ContentFile(image))
-
-            url_path = os.path.join(
-                settings.MEDIA_URL,
-                upload_to,
-                filename).replace(
-                '\\',
-                '/')
-            site_url = settings.SITEURL.rstrip('/') if settings.SITEURL.startswith('http') else settings.SITEURL
-            url = urljoin(site_url, url_path)
+            actual_name = storage.save(upload_path, ContentFile(image))
+            url = storage.url(actual_name)
 
             # should only have one 'Thumbnail' link
             obj, created = Link.objects.get_or_create(resource=self,

--- a/geonode/contrib/ldap/backend.py
+++ b/geonode/contrib/ldap/backend.py
@@ -1,0 +1,273 @@
+"""Custom auth backend that harmonizes ``django_auth_ldap`` and geonode
+
+This module provides an authentication backend that can be used together with
+``django_auth_ldap`` in order to provide group permissions based on LDAP groups
+
+If you just want to connect with an LDAP server for creating users and managing
+authentication (login and logout), then you don't need this and
+``django_auth_ldap`` is enough, provided that you set the correct variables in
+the geonode ``settings.py`` file.
+
+If you want to extract group information from LDAP and map it to geonode
+permissions you will need to use the auth backend supplied in this module
+(or a similar solution).
+
+
+Why this module exists
+----------------------
+
+``django_auth_ldap`` offers a very flexible and complete way to map groups
+to LDAP and use the permissions defined in django - however, geonode has a
+non-standard way of managing its groups and users, hence the need for this
+custom auth backend class.
+
+In a nutshell, geonode wants to manage group memberships using the
+``django.contrib.auth.models.Group`` class (i.e. the usual django way) **and**
+also with the ``geonode.groups.models.GroupMember`` class.
+
+"""
+
+import logging
+import pprint
+
+from django.db import transaction
+from django_auth_ldap import backend
+from geonode.groups.models import (
+    GroupProfile,
+    GroupMember,
+)
+import ldap
+
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+class GeonodeLdapBackend(backend.LDAPBackend):
+
+    def authenticate_ldap_user(self, ldap_user, password):
+        """Returns an authenticated Django user or None.
+
+        Authenticates against the LDAP directory and returns the corresponding
+        User object if successful. Returns None on failure.
+
+        This method is called by this backend's ``authenticate()`` method, which
+        is what django actually uses.
+
+        This method is only reimplemented because we ultimately want
+        django_auth_ldap to create instances of
+        ``geonode.people.models.GroupProfile`` instead of vanilla django groups.
+
+        Since the creation of groups is done deeper in
+        ``django_auth_ldap.backend._LDAPUser._mirror_groups()``, for a lack of
+        a better place to hook into, we need to start reimplementing at this
+        level in order to be able to modify it.
+
+        This current approach is certainly a hack. Unfortunately, as long as
+        geonode holds group memberships in both
+        ``django.contrib.auth.models.Group`` and
+        ``geonode.groups.models.GroupMember`` there does not seem to be a clean
+        way to map LDAP groups to geonode groups and still be able to use
+        geonode's permissions.
+
+        This method is reimplemented in order to provide support for custom
+        management of geonode groups. The intent is to reuse code from
+        ``django_auth_ldap`` as much as possible. As such, the _LDAPUser class
+        is being re-used too. In django_auth_ldap this is the method that starts
+        the user and group verification. We notoriously replace the following
+        _LDAPUser methods with custom ones:
+
+        * ``_LDAPUser._get_or_create_user()`` - we provide
+          ``CustomLdapBackend._get_or_create_user()``, which does the same job
+          but takes ``ldap_user`` as an input paremeter instead
+
+        * ``LDAPUser._mirror_groups()`` - we provide
+          ``CustomLdapBackend.mirror_groups()`` instead, which takes
+          ``ldap_user`` as an input paremeter instead and also has custom logic
+
+        """
+
+        user = None
+
+        try:
+            ldap_user._authenticate_user_dn(password)
+            ldap_user._check_requirements()
+            self._get_or_create_user(ldap_user)
+
+            user = ldap_user._user
+        except ldap_user.AuthenticationFailed as e:
+            logger.debug(
+                "Authentication failed for {}: {}".format(
+                    ldap_user._username, e)
+            )
+        except ldap.LDAPError as e:
+            results = backend.ldap_error.send(
+                ldap_user.backend.__class__,
+                context='authenticate',
+                user=ldap_user._user,
+                exception=e
+            )
+            if len(results) == 0:
+                logger.warning(
+                    "Caught LDAPError while authenticating {}: {}".format(
+                        ldap_user._username, pprint.pformat(e)
+                    )
+                )
+        except Exception as e:
+            logger.warning(
+                "{} while authenticating {}".format(e, ldap_user._username)
+            )
+            raise
+
+        return user
+
+    def _get_or_create_user(self, ldap_user, force_populate=False):
+        """Reimplemented based on django_auth_ldap _LDAPUser.get_or_create_user
+
+        Loads the User model object from the database or creates it if it
+        doesn't exist. Also populates the fields, subject to
+        AUTH_LDAP_ALWAYS_UPDATE_USER.
+
+        """
+
+        save_user = False
+
+        username = self.ldap_to_django_username(ldap_user._username)
+
+        ldap_user._user, built = self.get_or_build_user(username, ldap_user)
+        ldap_user._user.ldap_user = ldap_user
+        ldap_user._user.ldap_username = ldap_user._username
+
+        should_populate = (
+                force_populate or self.settings.ALWAYS_UPDATE_USER or built)
+
+        if built:
+            ldap_user._user.set_unusable_password()
+            save_user = True
+
+        if should_populate:
+            ldap_user._populate_user()
+            save_user = True
+
+            # Give the client a chance to finish populating the user just
+            # before saving.
+            backend.populate_user.send(
+                self.__class__,
+                user=ldap_user._user,
+                ldap_user=ldap_user
+            )
+
+        if save_user:
+            ldap_user._user.save()
+
+        # This has to wait until we're sure the user has a pk.
+        if self.settings.MIRROR_GROUPS or self.settings.MIRROR_GROUPS_EXCEPT:
+            ldap_user._normalize_mirror_settings()
+            self._mirror_groups(ldap_user)
+
+    def _mirror_groups(self, ldap_user):
+        """Reimplemented in order to generate ``people.GroupProfile`` instances
+
+        Mirrors the user's LDAP groups in the Django database and updates the
+        user's membership.
+
+        """
+
+        user = ldap_user._user
+        slug_map = utils.get_ldap_groups_map(user)
+        profile_slugs_set = frozenset(slug_map.keys())
+        current_group_profile_slugs = frozenset(
+            user.groups.values_list(
+                "groupprofile__slug",
+                flat=True
+            ).filter(groupprofile__slug__isnull=False)
+        )
+        MIRROR_GROUPS_EXCEPT = self.settings.MIRROR_GROUPS_EXCEPT
+        MIRROR_GROUPS = self.settings.MIRROR_GROUPS
+
+        if isinstance(MIRROR_GROUPS_EXCEPT, (set, frozenset)):
+            profile_slugs_set = (
+                    (profile_slugs_set - MIRROR_GROUPS_EXCEPT) |
+                    (current_group_profile_slugs & MIRROR_GROUPS_EXCEPT)
+            )
+        elif isinstance(MIRROR_GROUPS, (set, frozenset)):
+            profile_slugs_set = (
+                    (profile_slugs_set & MIRROR_GROUPS) |
+                    (current_group_profile_slugs - MIRROR_GROUPS)
+            )
+        if profile_slugs_set != current_group_profile_slugs:
+            existing_group_profiles = list(GroupProfile.objects.filter(
+                slug__in=profile_slugs_set).iterator())
+            existing_group_profile_slugs = frozenset(
+                profile.slug for profile in existing_group_profiles)
+            new_group_profiles = []
+            for profile_slug in profile_slugs_set:
+                if profile_slug not in existing_group_profile_slugs:
+                    profile_names = slug_map.get(profile_slug, {})
+                    group_profile, created = GroupProfile.objects.get_or_create(
+                        title=profile_names.get("sanitized", profile_slug),
+                        slug=profile_slug,
+                        defaults={
+                            "description": profile_names.get(
+                                "original", profile_slug)
+                        }
+                    )
+                    new_group_profiles.append(group_profile)
+            replace_user_groups(
+                user,
+                existing_group_profiles + new_group_profiles
+            )
+
+
+@transaction.atomic
+def replace_user_groups(user, group_profiles):
+    """Set user group memberships based on the input group_profiles
+
+    This function operates on both types of groups that currently exist in
+    geonode:
+
+    - regular ``django.contrib.auth.models.Group`` groups which are needed for
+      checking permissions
+
+    - geonode's custom ``geonode.groups.models.GroupProfile`` which are used as
+      profiles but also store membership information
+
+    All user memberships related with the ``GroupProfile`` class (which are
+    being mediated by the ``GroupMember`` model) are first deleted. The
+    companion ``Group`` memberships are also deleted.
+
+    Then new memberships are created according to the profiles specified in the
+    ``group_profiles`` parameter and the corresponding ``Group`` memberships
+    are also created.
+
+    """
+
+    remove_user_memberships(user)
+    for group in group_profiles:
+        add_groups_to_user(
+            user, group_profile=group, group=group.group)
+
+
+def remove_user_memberships(user):
+    """Remove user from all ``GroupMember`` instances and django groups
+
+    """
+
+    existing_group_profile_memberships = GroupMember.objects.filter(
+        user=user).values_list("group__slug", flat=True)
+    user.groups.filter(name__in=existing_group_profile_memberships).delete()
+    GroupMember.objects.filter(user=user).delete()
+
+
+def add_groups_to_user(user, group_profile, group):
+    """Adds groups to a user.
+
+    This will add both a `django.contrib.auth.models.Group` and a also a
+    ``geonode.groups.models.GroupProfile``, by means of creating a
+    ``geonode.groups.models.GroupMember``.
+
+    """
+
+    user.groups.add(group)
+    GroupMember.objects.create(
+        user=user, group=group_profile, role=GroupMember.MEMBER)

--- a/geonode/contrib/ldap/config.py
+++ b/geonode/contrib/ldap/config.py
@@ -1,0 +1,17 @@
+from django.template.defaultfilters import slugify
+from django_auth_ldap import config
+
+
+class GeonodeNestedGroupOfNamesType(config.NestedGroupOfNamesType):
+    """Reimplemented in order to truncate group names to 50 characters
+
+    This is needed since geonode's ``groups.GroupProfile`` model mandates
+    that the group's ``title`` and ``slug`` fields be at most 50 chars.
+
+    """
+
+    def group_name_from_info(self, group_info):
+        name = super(GeonodeNestedGroupOfNamesType, self).group_name_from_info(
+            group_info)
+        safe_name = slugify(name)[:50]
+        return safe_name

--- a/geonode/contrib/ldap/settings.py
+++ b/geonode/contrib/ldap/settings.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+try:
+    LDAP_GROUP_PROFILE_FILTERSTR = settings.GEONODE_LDAP_GROUP_PROFILE_FILTERSTR
+except AttributeError:
+    raise ImproperlyConfigured(
+        "Please set the GEONODE_LDAP_GROUP_PROFILE_FILTERSTR variable")
+
+LDAP_GROUP_NAME_ATTRIBUTE = getattr(
+    settings,
+    "GEONODE_LDAP_GROUP_NAME_ATTRIBUTE",
+    "cn"
+)

--- a/geonode/contrib/ldap/utils.py
+++ b/geonode/contrib/ldap/utils.py
@@ -1,0 +1,74 @@
+"""Custom utilities for managing LDAP logins"""
+
+from django.template.defaultfilters import slugify
+
+from django_auth_ldap import backend
+import ldap
+
+from . import settings
+
+
+def get_ldap_groups_map(user=None):
+    """Return a dict with group_slug, group_name for each LDAP group
+
+    If ``user`` is provided, returns only the groups that the user is a member
+    of in LDAP.
+
+    """
+
+    ldap_backend = backend.LDAPBackend()
+    conn = ldap.initialize(ldap_backend.settings.SERVER_URI)
+    conn.simple_bind_s(
+        ldap_backend.settings.BIND_DN,
+        ldap_backend.settings.BIND_PASSWORD
+    )
+    if user:
+        filter_ = _get_ldap_groups_filter(user, ldap_backend)
+    else:
+        filter_ = "{}".format(settings.LDAP_GROUP_PROFILE_FILTERSTR)
+    remote_groups = conn.search_s(
+        base=ldap_backend.settings.GROUP_SEARCH.base_dn,
+        scope=ldap.SCOPE_SUBTREE,
+        filterstr=filter_
+    )
+    result = {}
+    for cn, attributes in remote_groups:
+        group_name = " ".join(
+            attributes[settings.LDAP_GROUP_NAME_ATTRIBUTE])
+        sanitized_name = sanitize_group_name(group_name)
+        result[slugify(sanitized_name)] = {
+            "original": group_name,
+            "sanitized": sanitized_name,
+        }
+    return result
+
+
+def sanitize_group_name(name):
+    """Return a name that is suitable for use when creating geonode groups
+
+    Geonode currently uses two group types:
+
+    * standard ``django.contrib.auth.models.Group``
+
+    * custom ``geonode.groups.models.GroupProfile`` - this model also manages
+      user memberships, through  the ``geonode.groups.models.GroupMember``
+      class. These memberships are used for the UI, but they are not used for
+      enforcing permissions - the standard ``Group`` and its relation to the
+      user model is used for that
+
+    Geonode ``GroupProfile`` titles and slugs are restricted to 50 chars
+    and the ``Group`` names are set from the ``GroupProfile.slug``
+
+    """
+
+    sanitized_name = name[:50]
+    return sanitized_name
+
+
+def _get_ldap_groups_filter(user, ldap_backend):
+    if not hasattr(user, "ldap_user"):
+        user = ldap_backend.populate_user(user.username)
+    return "(&{}(member={}))".format(
+        settings.LDAP_GROUP_PROFILE_FILTERSTR,
+        user.ldap_user.dn
+    )

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -38,6 +38,7 @@ from geonode.geoserver.helpers import (cascading_delete,
                                        create_gs_thumbnail,
                                        _stylefilterparams_geowebcache_layer,
                                        _invalidate_geowebcache_layer)
+from geonode.catalogue.models import catalogue_post_save
 from geonode.base.models import ResourceBase
 from geonode.people.models import Profile
 from geonode.layers.models import Layer
@@ -93,7 +94,7 @@ def geoserver_post_save(instance, sender, created, **kwargs):
             try:
                 create_gs_thumbnail(instance, overwrite=True, check_bbox=True)
             except BaseException:
-                logger.warn("!WARNING! - Failure while Creating Thumbnail for Layer [%s]" % (instance.alternate))
+                logger.warn("Failure Creating Thumbnail for Layer [%s]" % (instance.alternate))
 
 
 def geoserver_post_save_local(instance, *args, **kwargs):
@@ -328,6 +329,9 @@ def geoserver_post_save_local(instance, *args, **kwargs):
 
     # Refresh from DB
     instance.refresh_from_db()
+
+    # Updating the Catalogue
+    catalogue_post_save(instance=instance, sender=instance.__class__)
 
     # store the resource to avoid another geoserver call in the post_save
     if gs_resource:

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1217,7 +1217,7 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             self.assertIsNotNone(test_perm_layer.bbox)
             self.assertIsNotNone(test_perm_layer.srid)
             self.assertIsNotNone(test_perm_layer.link_set)
-            self.assertEquals(len(test_perm_layer.link_set.all()), 17)
+            self.assertEquals(len(test_perm_layer.link_set.all()), 18)
 
             # Layer Manipulation
             from geonode.geoserver.upload import geoserver_upload

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1189,7 +1189,23 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', None)
 
 GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY = os.getenv('GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY', 'mapstore')
 
-MAP_BASELAYERS = []
+MAP_BASELAYERS = [{
+        "source": {"ptype": "gxp_olsource"},
+        "type": "OpenLayers.Layer",
+        "args": ["No background"],
+        "name": "background",
+        "visibility": False,
+        "fixed": True,
+        "group":"background"
+    },
+    {
+        "source": {"ptype": "gxp_osmsource"},
+        "type": "OpenLayers.Layer.OSM",
+        "name": "mapnik",
+        "visibility": True,
+        "fixed": True,
+        "group": "background"
+    }]
 
 """
 To enable the GeoExt based Client:
@@ -1204,15 +1220,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'geoext':
     if 'geoexplorer' not in INSTALLED_APPS:
         INSTALLED_APPS += ('geoexplorer', )
 
-    MAP_BASELAYERS = [{
-        "source": {"ptype": "gxp_olsource"},
-        "type": "OpenLayers.Layer",
-        "args": ["No background"],
-        "name": "background",
-        "visibility": False,
-        "fixed": True,
-        "group":"background"
-    },
+    # MAP_BASELAYERS += [
     # {
     #     "source": {"ptype": "gxp_olsource"},
     #     "type": "OpenLayers.Layer.XYZ",
@@ -1223,15 +1231,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'geoext':
     #     "visibility": False,
     #     "fixed": True,
     #     "group":"background"
-    # },
-    {
-        "source": {"ptype": "gxp_osmsource"},
-        "type": "OpenLayers.Layer.OSM",
-        "name": "mapnik",
-        "visibility": True,
-        "fixed": True,
-        "group": "background"
-    }]
+    # }]
 
     if BING_API_KEY:
         BASEMAP = {
@@ -1255,7 +1255,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'geoext':
             },
             'name': 'SATELLITE',
             'fixed': True,
-            'visibility': False,
+            'visibility': True,
             'group': 'background'
         }
         MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1189,6 +1189,8 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', None)
 
 GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY = os.getenv('GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY', 'mapstore')
 
+MAP_BASELAYERS = []
+
 """
 To enable the GeoExt based Client:
 1. pip install django-geoexplorer==4.0.42
@@ -1258,7 +1260,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'geoext':
         }
         MAP_BASELAYERS.append(BASEMAP)
 
-    if 'geonode.geoserver' in INSTALLED_APPS:
+    if USE_GEOSERVER:
         LOCAL_GEOSERVER = {
             "source": {
                 "ptype": "gxp_wmscsource",

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -124,16 +124,7 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         # test for correct service link articulation
         for link in record.references:
             if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-                if link['scheme'] == 'OGC:WMS':
-                    self.assertEqual(
-                        link['url'],
-                        '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION),
-                        'Expected a specific OGC:WMS URL')
-                elif link['scheme'] == 'OGC:WFS':
-                    self.assertEqual(
-                        link['url'],
-                        '{}wfs'.format(settings.GEOSERVER_PUBLIC_LOCATION),
-                        'Expected a specific OGC:WFS URL')
+                self.assertTrue(settings.GEOSERVER_PUBLIC_LOCATION in link['url'])
             elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
                 if link['scheme'] == 'OGC:WMS':
                     self.assertEqual(

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -127,9 +127,9 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
                 if link['scheme'] == 'OGC:WMS':
                     self.assertEquals(link['url'], '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION))
                 elif link['scheme'] == 'OGC:WFS':
-                    self.assertEquals(link['url'], '{}wfs'.format(settings.GEOSERVER_PUBLIC_LOCATION))
+                    self.assertEquals(link['url'], '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION))
                 elif link['scheme'] == 'OGC:WCS':
-                    self.assertEquals(link['url'], '{}wcs'.format(settings.GEOSERVER_PUBLIC_LOCATION))
+                    self.assertEquals(link['url'], '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION))
             elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
                 if link['scheme'] == 'OGC:WMS':
                     self.assertEqual(

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -125,15 +125,11 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         for link in record.references:
             if check_ogc_backend(geoserver.BACKEND_PACKAGE):
                 if link['scheme'] == 'OGC:WMS':
-                    self.assertEqual(
-                        link['url'],
-                        '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION),
-                        'Expected a specific OGC:WMS URL')
+                    self.assertEquals(link['url'], '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION))
                 elif link['scheme'] == 'OGC:WFS':
-                    self.assertEqual(
-                        link['url'],
-                        '{}wfs'.format(settings.GEOSERVER_PUBLIC_LOCATION),
-                        'Expected a specific OGC:WFS URL')
+                    self.assertEquals(link['url'], '{}wfs'.format(settings.GEOSERVER_PUBLIC_LOCATION))
+                elif link['scheme'] == 'OGC:WCS':
+                    self.assertEquals(link['url'], '{}wcs'.format(settings.GEOSERVER_PUBLIC_LOCATION))
             elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
                 if link['scheme'] == 'OGC:WMS':
                     self.assertEqual(

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -124,7 +124,16 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         # test for correct service link articulation
         for link in record.references:
             if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-                self.assertTrue(settings.GEOSERVER_PUBLIC_LOCATION in link['url'])
+                if link['scheme'] == 'OGC:WMS':
+                    self.assertEqual(
+                        link['url'],
+                        '{}ows'.format(settings.GEOSERVER_PUBLIC_LOCATION),
+                        'Expected a specific OGC:WMS URL')
+                elif link['scheme'] == 'OGC:WFS':
+                    self.assertEqual(
+                        link['url'],
+                        '{}wfs'.format(settings.GEOSERVER_PUBLIC_LOCATION),
+                        'Expected a specific OGC:WFS URL')
             elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
                 if link['scheme'] == 'OGC:WMS':
                     self.assertEqual(

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1510,7 +1510,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                           width)
 
         for ext, name, mime, wms_url in links:
-            Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        name=ugettext(name),
                                        defaults=dict(
@@ -1529,7 +1530,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             for ext, name, mime, wfs_url in links:
                 if mime == 'SHAPE-ZIP':
                     name = 'Zipped Shapefile'
-                Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).delete()
+                if Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).count() > 1:
+                    Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).delete()
                 Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                            url=wfs_url,
                                            defaults=dict(
@@ -1547,7 +1549,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                               srid)
 
         for ext, name, mime, wcs_url in links:
-            Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=wcs_url,
                                        defaults=dict(
@@ -1589,7 +1592,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         html_link_url = '%s%s' % (
             site_url, instance.get_absolute_url())
 
-        Link.objects.filter(resource=instance.resourcebase_ptr, url=html_link_url).delete()
+        if Link.objects.filter(resource=instance.resourcebase_ptr, url=html_link_url).count() > 1:
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=html_link_url).delete()
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=html_link_url,
                                    defaults=dict(
@@ -1611,7 +1615,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                 instance.alternate + '&STYLE=' + style.name + \
                 '&legend_options=fontAntiAliasing:true;fontSize:12;forceLabels:on'
 
-            Link.objects.filter(resource=instance.resourcebase_ptr, url=legend_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, url=legend_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, url=legend_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=legend_url,
                                        defaults=dict(
@@ -1627,7 +1632,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         ogc_wms_path = 'ows'
         ogc_wms_url = urljoin(ogc_server_settings.public_url, ogc_wms_path)
         ogc_wms_name = 'OGC WMS: %s Service' % instance.workspace
-        Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).delete()
+        if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).count() > 1:
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).delete()
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=ogc_wms_url,
                                    defaults=dict(
@@ -1644,7 +1650,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wfs_path = 'ows'
             ogc_wfs_url = urljoin(ogc_server_settings.public_url, ogc_wfs_path)
             ogc_wfs_name = 'OGC WFS: %s Service' % instance.workspace
-            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wfs_url,
                                        defaults=dict(
@@ -1661,7 +1668,8 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wcs_path = 'ows'
             ogc_wcs_url = urljoin(ogc_server_settings.public_url, ogc_wcs_path)
             ogc_wcs_name = 'OGC WCS: %s Service' % instance.workspace
-            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wcs_url,
                                        defaults=dict(

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1510,8 +1510,6 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                           width)
 
         for ext, name, mime, wms_url in links:
-            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).count() > 1:
-                Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        name=ugettext(name),
                                        defaults=dict(
@@ -1530,8 +1528,6 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             for ext, name, mime, wfs_url in links:
                 if mime == 'SHAPE-ZIP':
                     name = 'Zipped Shapefile'
-                if Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).count() > 1:
-                    Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).delete()
                 Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                            url=wfs_url,
                                            defaults=dict(
@@ -1549,8 +1545,6 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                               srid)
 
         for ext, name, mime, wcs_url in links:
-            if Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).count() > 1:
-                Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=wcs_url,
                                        defaults=dict(
@@ -1632,13 +1626,13 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         ogc_wms_path = 'ows'
         ogc_wms_url = urljoin(ogc_server_settings.public_url, ogc_wms_path)
         ogc_wms_name = 'OGC WMS: %s Service' % instance.workspace
-        if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).count() > 1:
-            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).delete()
+        if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wms_name, url=ogc_wms_url).count() > 1:
+            Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wms_name, url=ogc_wms_url).delete()
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=ogc_wms_url,
+                                   name=ogc_wms_name,
                                    defaults=dict(
                                        extension='html',
-                                       name=ogc_wms_name,
                                        url=ogc_wms_url,
                                        mime='text/html',
                                        link_type='OGC:WMS',
@@ -1650,13 +1644,13 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wfs_path = 'ows'
             ogc_wfs_url = urljoin(ogc_server_settings.public_url, ogc_wfs_path)
             ogc_wfs_name = 'OGC WFS: %s Service' % instance.workspace
-            if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).count() > 1:
-                Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wfs_name, url=ogc_wfs_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wfs_name, url=ogc_wfs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wfs_url,
+                                       name=ogc_wfs_name,
                                        defaults=dict(
                                            extension='html',
-                                           name=ogc_wfs_name,
                                            url=ogc_wfs_url,
                                            mime='text/html',
                                            link_type='OGC:WFS',
@@ -1668,13 +1662,13 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wcs_path = 'ows'
             ogc_wcs_url = urljoin(ogc_server_settings.public_url, ogc_wcs_path)
             ogc_wcs_name = 'OGC WCS: %s Service' % instance.workspace
-            if Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).count() > 1:
-                Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).delete()
+            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wcs_name, url=ogc_wcs_url).count() > 1:
+                Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wcs_name, url=ogc_wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wcs_url,
+                                       name=ogc_wcs_name,
                                        defaults=dict(
                                            extension='html',
-                                           name=ogc_wcs_name,
                                            url=ogc_wcs_url,
                                            mime='text/html',
                                            link_type='OGC:WCS',

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1510,6 +1510,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                           width)
 
         for ext, name, mime, wms_url in links:
+            Link.objects.filter(resource=instance.resourcebase_ptr, name=ugettext(name)).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        name=ugettext(name),
                                        defaults=dict(
@@ -1528,6 +1529,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             for ext, name, mime, wfs_url in links:
                 if mime == 'SHAPE-ZIP':
                     name = 'Zipped Shapefile'
+                Link.objects.filter(resource=instance.resourcebase_ptr, url=wfs_url).delete()
                 Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                            url=wfs_url,
                                            defaults=dict(
@@ -1545,6 +1547,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                               srid)
 
         for ext, name, mime, wcs_url in links:
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=wcs_url,
                                        defaults=dict(
@@ -1586,6 +1589,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         html_link_url = '%s%s' % (
             site_url, instance.get_absolute_url())
 
+        Link.objects.filter(resource=instance.resourcebase_ptr, url=html_link_url).delete()
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=html_link_url,
                                    defaults=dict(
@@ -1607,6 +1611,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                 instance.alternate + '&STYLE=' + style.name + \
                 '&legend_options=fontAntiAliasing:true;fontSize:12;forceLabels:on'
 
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=legend_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=legend_url,
                                        defaults=dict(
@@ -1622,6 +1627,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         ogc_wms_path = 'ows'
         ogc_wms_url = urljoin(ogc_server_settings.public_url, ogc_wms_path)
         ogc_wms_name = 'OGC WMS: %s Service' % instance.workspace
+        Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wms_url).delete()
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=ogc_wms_url,
                                    defaults=dict(
@@ -1638,6 +1644,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wfs_path = 'ows'
             ogc_wfs_url = urljoin(ogc_server_settings.public_url, ogc_wfs_path)
             ogc_wfs_name = 'OGC WFS: %s Service' % instance.workspace
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wfs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wfs_url,
                                        defaults=dict(
@@ -1654,6 +1661,7 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             ogc_wcs_path = 'ows'
             ogc_wcs_url = urljoin(ogc_server_settings.public_url, ogc_wcs_path)
             ogc_wcs_name = 'OGC WCS: %s Service' % instance.workspace
+            Link.objects.filter(resource=instance.resourcebase_ptr, url=ogc_wcs_url).delete()
             Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                        url=ogc_wcs_url,
                                        defaults=dict(


### PR DESCRIPTION
This PR adds a new contrib package to geonode with some utilities that allow tighter integration with LDAP servers.

Included in the PR:

-  Updated docs page with instructions on how to use this contrib package and an example configuraton
-  A custom authentication backend that is able to create geonode groups and update users' memberships from the group structure specified in LDAP
-  Some extra utilities that deal with the specifics of geonode groups like maximum size of `title` and `slug` fields


### Note
This PR was prepared against current official geonode master, hence the other commits that are showing here