### PR TITLE
Fix storage manager tests

### DIFF
--- a/geonode/storage/tests.py
+++ b/geonode/storage/tests.py
@@ -368,10 +368,10 @@ class TestStorageManager(TestCase):
         expected = ['/opt/full/path/to/file', '/opt/full/path/to/file']
         old_files = ['/opt/full/path/to/file', '/opt/full/path/to/file']
         new_files = ['geonode/base/fixtures/test_sld.sld', 'geonode/base/fixtures/test_data.json']
-        l = create_single_layer('storage_manager')
-        l.files = old_files
-        l.save()
-        output = self.sut().replace(l, new_files)
+        layer = create_single_layer('storage_manager')
+        layer.files = old_files
+        layer.save()
+        output = self.sut().replace(layer, new_files)
         self.assertEqual(2, len(output['files']))
         self.assertListEqual(expected, output['files'])
 
@@ -385,9 +385,9 @@ class TestStorageManager(TestCase):
         path.return_value = '/opt/full/path/to/file'
         strg.return_value = '/opt/full/path/to/file'
         expected = '/opt/full/path/to/file'
-        l = create_single_layer('storage_manager')
-        l.files = ['/opt/full/path/to/file2']
-        l.save()
+        layer = create_single_layer('storage_manager')
+        layer.files = ['/opt/full/path/to/file2']
+        layer.save()
         with open('geonode/base/fixtures/test_sld.sld') as new_file:
-            output = self.sut().replace(l, new_file)
+            output = self.sut().replace(layer, new_file)
         self.assertListEqual([expected], output['files'])


### PR DESCRIPTION
Fix storage manager tests

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
